### PR TITLE
Fixes for the latest version of Hugo and the Cactus theme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,11 @@ disqusShortname = "celinelenobledotcom"
 
 SectionPagesMenu = "main"
 
+[markup]
+	[markup.goldmark]
+	[markup.goldmark.renderer]
+		unsafe = true
+
 [params]
 	name = "Celine Lenoble"
 	description = "Celine Lenoble Portfolio"

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,5 +1,5 @@
 <nav class="main-nav">
-	{{ $currentURL := .URL }}
+	{{ $currentURL := .RelPermalink }}
 	{{ $currentSection := .Section }}
 	{{ $baseURL := .Site.BaseURL }}
 	{{ range $menu := .Site.Params.sectionMenus }}


### PR DESCRIPTION
- Update to latest version of Cactus theme
- Enable "unsafe" mode on the Markdown engine to keep rendering HTML
tags
- Fix deprecated .URL variable